### PR TITLE
Reduce memory usage of Cartridge::Mbc1

### DIFF
--- a/lib/rubyboy/cartridge/mbc1.rb
+++ b/lib/rubyboy/cartridge/mbc1.rb
@@ -18,13 +18,13 @@ module Rubyboy
       end
 
       def set_methods
-        0xc000.times do |addr|
-          @read_methods[addr] =
-            case addr
-            when 0x0000..0x3fff then -> { @rom.data[addr] }
-            when 0x4000..0x7fff then -> { @rom.data[addr + (@rom_bank - 1) * 0x4000] }
-            when 0xa000..0xbfff
-              lambda do
+        0xc.times do |prefix|
+          @read_methods[prefix] =
+            case prefix
+            when 0x0..0x3 then ->(addr) { @rom.data[addr] }
+            when 0x4..0x7 then ->(addr) { @rom.data[addr + (@rom_bank - 1) * 0x4000] }
+            when 0xa..0xb
+              lambda do |addr|
                 if @ram_enable
                   if @ram_banking_mode
                     @ram.eram[addr - 0xa000 + @ram_bank * 0x800]
@@ -38,19 +38,19 @@ module Rubyboy
             end
         end
 
-        0xc000.times do |addr|
-          @write_methods[addr] =
-            case addr
-            when 0x0000..0x1fff then ->(value) { @ram_enable = value & 0x0f == 0x0a }
-            when 0x2000..0x3fff
-              lambda do |value|
+        0xc.times do |prefix|
+          @write_methods[prefix] =
+            case prefix
+            when 0x0..0x1 then ->(_addr, value) { @ram_enable = value & 0x0f == 0x0a }
+            when 0x2..0x3
+              lambda do |_addr, value|
                 @rom_bank = value & 0x1f
                 @rom_bank = 1 if @rom_bank == 0
               end
-            when 0x4000..0x5fff then ->(value) { @ram_bank = value & 0x03 }
-            when 0x6000..0x7fff then ->(value) { @ram_banking_mode = value & 0x01 == 0x01 }
-            when 0xa000..0xbfff
-              lambda do |value|
+            when 0x4..0x5 then ->(_addr, value) { @ram_bank = value & 0x03 }
+            when 0x6..0x7 then ->(_addr, value) { @ram_banking_mode = value & 0x01 == 0x01 }
+            when 0xa..0xb
+              lambda do |addr, value|
                 if @ram_enable
                   if @ram_banking_mode
                     @ram.eram[addr - 0xa000 + @ram_bank * 0x800] = value
@@ -64,11 +64,11 @@ module Rubyboy
       end
 
       def read_byte(addr)
-        @read_methods[addr].call
+        @read_methods[addr >> 12].call(addr)
       end
 
       def write_byte(addr, value)
-        @write_methods[addr].call(value)
+        @write_methods[addr >> 12].call(addr, value)
       end
     end
   end


### PR DESCRIPTION
Precomputing one Proc per possible address amount of 8MiB of memory and almost 100k objects the GC as to scan etc.

This can be reduced to just 24 objects with only an extra bitshift on access.